### PR TITLE
Add customCommand and associated method

### DIFF
--- a/devicetypes/greghesp/assistant-relay.src/assistant-relay.groovy
+++ b/devicetypes/greghesp/assistant-relay.src/assistant-relay.groovy
@@ -27,6 +27,7 @@ metadata {
 		capability "Actuator"
         command "customBroadcast", [ "string", "string" ]
         command "broadcast", [ "string" ]
+        command "customCommand", [ "string" ]
         command "nestStartStream", ["string", "string", "string"]
         command "nestStopStream", ["string"]
         capability "Polling"
@@ -52,6 +53,11 @@ def broadcast(text) {
 	def eText = URLEncoder.encode(text, "UTF-8");
 
   httpPostJSON("/broadcast?preset=${eText}")
+}
+
+def customCommand(text) {
+	def eText = URLEncoder.encode(text, "UTF-8");
+    httpPostJSON("/custom?command=${eText}")
 }
 
 def nestStartStream(camera, chromecast, user) {


### PR DESCRIPTION
I added a customCommand method to the device handler just to see if I could see responses to non-broadcast requests.  Not sure how it could be used for anything yet, but you can pull it in if you desire.
Here's an example of the logged output:

Received command what time is it
Google Assistant: The time is 7:21 PM.
Conversation Complete