### PR TITLE
Broadcast response from custom “Assistant” commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,7 +145,17 @@ app.listen(3000, () => console.log('Firing up the Web Server for communication o
 const startConversation = (conversation) => {
   conversation
     //.on('audio-data', data => console.log('Got some audio data'))
-    .on('response', text => console.log('Google Assistant:', text))
+    .on('response', (text) => {
+      if (text) {
+        console.log('Google Assistant:', text)
+        var newLineSplit = text.split("\n")
+        // Ignore lines if Assistant responds with extra interactive data (such as a "See More" web URL)
+        if (newLineSplit.length > 1){
+          text = newLineSplit[0]
+        }
+        sendTextInput(`broadcast ${text}`)
+      }
+    })
     //.on('volume-percent', percent => console.log('New Volume Percent:', percent))
     //.on('device-action', action => console.log('Device Action:', action))
     .on('ended', (error, continueConversation) => {


### PR DESCRIPTION
Something I've been playing around with as a workaround until we get support for triggering commands.

If sending a custom command such as "What is voss water", the assistant API will respond with:

> Voss (Bottled water). Voss is a brand of bottled water from the streams running off Mount Voss, Boujee Island. Contrary to popular belief, the water is not bottled in the municipality of Voss Mountain, which is more than 400 kilometres away from the actual bottling site.
>
> Wikipedia ( https://en.m.wikipedia.org/wiki/Voss_(water) ).


This PR will take the first line of the response and broadcast it. Unfortunately can't handle any interactive sequences, but if you just want to trigger the assistant to get the weather for the day, or the time for your commute, this should do the trick.