### PR TITLE
Resolved duplicate http issue

### DIFF
--- a/server/assistant.js
+++ b/server/assistant.js
@@ -102,7 +102,7 @@ var self = module.exports = {
         .on('audio-data', data => {
           fileStream.write(data)
           // set a random parameter on audio url to prevent caching
-          response.audio = `http://${global.config.baseUrl}/audio?v=${Math.floor(Math.random() *  100)}`
+          response.audio = `${global.config.baseUrl}/audio?v=${Math.floor(Math.random() *  100)}`
         })
         .on('response', (text) => {
           if (text) {


### PR DESCRIPTION
There is a doubling of the "http://" text in the json response as the sample baseUrl variable in config.json includes the http and the statement in assistant.js adds another http to the string. If entered as outlined, it will produce a response with duplicate http like the below:

{
    "audio": "http://http://192.168.1.167:3000/audio?v=76",
    "success": true
}