### PR TITLE
Changed example baseUrl to correct format

### DIFF
--- a/server/configurations/config.json
+++ b/server/configurations/config.json
@@ -6,7 +6,7 @@
     "start": 21,
     "end": 8
   },
-  "baseUrl": "http://your.ip.address:port",
+  "baseUrl": "your.ip.address:port",
   "conversation": {
     "language": "en-US",
     "audio": {


### PR DESCRIPTION
The protocol is automatically added where `baseUrl` is used (`server/assistant.js`), so including it in `config.json` led to the protocl being repeated (`http://http://`).