### PR TITLE
Fix audio not playing over a reverse proxy

### DIFF
--- a/client/src/components/PlayButton/index.js
+++ b/client/src/components/PlayButton/index.js
@@ -34,7 +34,7 @@ function PlayButton({timestamp, url}) {
     return (
         <div>
             <Sound
-                url={url ? url : `http://${ip}:${port}/server/audio?v=${timestamp}`}
+                url={url ? url : `/server/audio?v=${timestamp}`}
                 onFinishedPlaying={() => PlayStop()}
                 playStatus={status}
             />

--- a/relay/routes/index.js
+++ b/relay/routes/index.js
@@ -81,7 +81,7 @@ router.post('/assistant', async(req, res) => {
     conversation
         .on('audio-data',async(data) => {
           fileStream.write(data);
-          response.audio = `http://${ip.address()}:${port}/server/audio?v=${timestamp}`
+          response.audio = `/server/audio?v=${timestamp}`
         })
         .on('response', (text) => {
           response.response = text;


### PR DESCRIPTION
Currently, audio samples are always loaded by IP which does not work over reverse proxy connections.  
The server hostname and port are not explicitly needed here either, so this commit removes them.