### PR TITLE
Remove erroneous 'run' argument

### DIFF
--- a/documentation-src/Assistant Relay/docs/getting-started/installation.md
+++ b/documentation-src/Assistant Relay/docs/getting-started/installation.md
@@ -17,7 +17,7 @@ To install Assistant Relay, unzip the contents of `release.zip` to a folder of y
 
 In the `assistant-relay` folder, open a terminal/command window and run the below command to install the required dependencies
 ```
-npm run i
+npm i
 ``` 
 
 


### PR DESCRIPTION
Your latest release cut says to run `npm i` which works great. 

![image](https://user-images.githubusercontent.com/8226466/74941789-a7f70a00-53c1-11ea-8a9d-65a1e7d2ec27.png)

This getting started doc has a run command that gunks up npm's works.

P.S. Thanks for the incredible tool. Do you have a paypal/venmo/etc. so I can send you a beer tip?