### PR TITLE
Fix broken "Get started" link on the front page

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -71,7 +71,7 @@ function Home() {
                 'button button--outline button--secondary button--lg',
                 styles.getStarted,
               )}
-              to={useBaseUrl('docs/')}>
+              to={useBaseUrl('docs/getting-started/installation')}>
               Get Started
             </Link>
           </div>


### PR DESCRIPTION
Link to "Get started" Button to page: getting-started/installation